### PR TITLE
ci: fix failing ci build for sphinx documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: ammaraskar/sphinx-action@master
         with:
-          pre-build-command: "pip install furo"
+          pre-build-command: "pip install furo pygments==2.11.2"
           build-command: "sphinx-build -b html -W . _build"
           docs-folder: "docs/"
 

--- a/.github/workflows/sphinx_check.yml
+++ b/.github/workflows/sphinx_check.yml
@@ -14,6 +14,6 @@ jobs:
 
       - uses: ammaraskar/sphinx-action@master
         with:
-          pre-build-command: "pip install furo"
+          pre-build-command: "pip install furo pygments==2.11.2"
           build-command: "sphinx-build -b html -W . _build"
           docs-folder: "docs/"


### PR DESCRIPTION
Fix broken dependency pygments==2.11.2 caused errors in CI builds for Sphinx documentation.