### PR TITLE
refactor: update methods now use backend calls

### DIFF
--- a/packages/renderer/src/store/Modules/PermissionsState.ts
+++ b/packages/renderer/src/store/Modules/PermissionsState.ts
@@ -78,7 +78,7 @@ class PermissionsStateActions extends Actions<PermissionsState, PermissionsState
     const existingPermissions = this.state.permissions.get(userId);
     const permissionsSet: ErrorResult<boolean> = await updatePermissions(userId, (existingPermissions)? undom(existingPermissions.concat(permissions)):permissions);
     if(permissionsSet.res && !permissionsSet.error) {
-      this.commit('addPermissions', {userId, permissions});
+      this.dispatch('retrievePermissions', userId);
     } else if(this.errorState) {
       this.errorState.dispatch('setError', permissionsSet.error);
       if(permissionsSet.errorMsg) {
@@ -91,7 +91,7 @@ class PermissionsStateActions extends Actions<PermissionsState, PermissionsState
   async updateAllPermissions({userId, permissions}:{userId: string, permissions: Permissions}) {
     const permissionsSet: ErrorResult<boolean> = await updatePermissions(userId, permissions);
     if(permissionsSet.res && !permissionsSet.error) {
-      this.commit('setPermissions', {userId, permissions});
+      this.dispatch('retrievePermissions', userId);
     } else if(this.errorState) {
       this.errorState.dispatch('setError', permissionsSet.error);
       if(permissionsSet.errorMsg) {

--- a/packages/renderer/src/store/Modules/UserState.ts
+++ b/packages/renderer/src/store/Modules/UserState.ts
@@ -86,7 +86,7 @@ class UserStateActions extends Actions<UserState, UserStateGetters, UserStateMut
   async updateUser(user: User) {
     const userUpdated:ErrorResult<boolean> = await updateUser(undom(user));
     if(userUpdated.res && !userUpdated.error) {
-      this.commit('updateUser', user);
+      this.dispatch('retreiveUserById', user.id);
     } else if(this.errorState) {
       this.errorState.dispatch('setError', userUpdated.error);
       if(userUpdated.errorMsg) {

--- a/packages/renderer/src/views/MainApplication.vue
+++ b/packages/renderer/src/views/MainApplication.vue
@@ -162,7 +162,7 @@
     const title = Math.random().toString(36).substring(2, 15);
     const start: Date = new Date();
     const end:Date = new Date(start.toISOString());
-    end.setHours(end.getHours() * 5);
+    end.setHours(end.getHours() + 5);
     operationsState.dispatch('createOperation', {
       id: '',
       title,


### PR DESCRIPTION
Change vuex state update methods to use backend calls to get updated entities instead of using the sent ones.