### PR TITLE
refactor(vuex-states): change to method call style

### DIFF
--- a/packages/renderer/src/store/Modules/ErrorState.ts
+++ b/packages/renderer/src/store/Modules/ErrorState.ts
@@ -37,12 +37,12 @@ class ErrorStateMutations extends Mutations<ErrorState> {
  */
 class ErrorStateActions extends Actions<ErrorState, ErrorStateGetters, ErrorStateMutations, ErrorStateActions> {
   async setError(error: boolean) {
-    this.commit('setError', error);
-    setTimeout(() => this.commit('setError', false), 10_000);
+    this.mutations.setError(error);
+    setTimeout(() => this.mutations.setError(false), 10_000);
   }
   async setErrorMessage(errorMessage: string) {
-    this.commit('setErrorMessage', errorMessage);
-    setTimeout(() => this.commit('setErrorMessage', ''), 10_000);
+    this.mutations.setErrorMessage(errorMessage);
+    setTimeout(() => this.mutations.setErrorMessage(''), 10_000);
   }
 }
 

--- a/packages/renderer/src/store/Modules/LoginState.ts
+++ b/packages/renderer/src/store/Modules/LoginState.ts
@@ -59,32 +59,32 @@ class LoginStateActions extends Actions<LoginState, LoginStateGetters, LoginStat
   }
 
   async login({username, password}:{username:string, password:string}) {
-    await this.dispatch('setLoggingIn', true);
+    await this.actions.setLoggingIn(true);
     const loggedIn:ErrorResult<boolean> = await login(username, password);
-    await this.dispatch('setLoggingIn', false);
+    await this.actions.setLoggingIn(false);
     if(loggedIn.res && !loggedIn.error) {
-      this.commit('setLoggedIn', loggedIn.res);
-      this.commit('setLoggedInUser', username);
+      this.mutations.setLoggedIn(loggedIn.res);
+      this.mutations.setLoggedInUser(username);
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', loggedIn.error);
+      this.errorState.actions.setError(loggedIn.error);
       if(loggedIn.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', loggedIn.errorMsg);
+        this.errorState.actions.setErrorMessage(loggedIn.errorMsg);
       }
     } else {
       console.error('Missing Error State');
     }
   }
   async setLoggingIn(loggingIn: boolean) {
-    this.commit('setLoggingIn', loggingIn);
+    this.mutations.setLoggingIn(loggingIn);
   }
   async logout() {
     const loggedOut:ErrorResult<boolean> = await logout();
     if(loggedOut.res && !loggedOut.error) {
-      this.commit('setLoggedIn', false);
+      this.mutations.setLoggedIn(false);
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', loggedOut.error);
+      this.errorState.actions.setError(loggedOut.error);
       if(loggedOut.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', loggedOut.errorMsg);
+        this.errorState.actions.setErrorMessage(loggedOut.errorMsg);
       }
     } else {
       console.error('Missing Error State');

--- a/packages/renderer/src/store/Modules/OperationsState.ts
+++ b/packages/renderer/src/store/Modules/OperationsState.ts
@@ -72,11 +72,11 @@ class OperationsStateActions extends Actions<OperationsState, OperationsStateGet
   async createOperation(operation: Operation) {
     const createdOperation: ErrorResult<Operation> = await createOperation(undom(operation));
     if(createdOperation.res && !createdOperation.error) {
-      this.commit('addOperation', createdOperation.res);
+      this.mutations.addOperation(createdOperation.res);
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', createdOperation.error);
+      this.errorState.actions.setError(createdOperation.error);
       if(createdOperation.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', createdOperation.errorMsg);
+        this.errorState.actions.setErrorMessage(createdOperation.errorMsg);
       }
     } else {
       console.error('Missing Error State');
@@ -86,11 +86,11 @@ class OperationsStateActions extends Actions<OperationsState, OperationsStateGet
   async updateOperation(operation: Operation) {
     const operationUpdated: ErrorResult<boolean> = await updateOperation(undom(operation));
     if(operationUpdated.res && !operationUpdated.error) {
-        this.dispatch('retrieveOperation', operation.id);
+        this.actions.retrieveOperation(operation.id);
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', operationUpdated.error);
+      this.errorState.actions.setError(operationUpdated.error);
       if(operationUpdated.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', operationUpdated.errorMsg);
+        this.errorState.actions.setErrorMessage(operationUpdated.errorMsg);
       }
     } else {
       console.error('Missing Error State');
@@ -100,11 +100,11 @@ class OperationsStateActions extends Actions<OperationsState, OperationsStateGet
   async retrieveOperation(operationId: string) {
     const retrievedOperation: ErrorResult<Operation> = await retrieveOperation(operationId);
     if(retrievedOperation.res && !retrievedOperation.error) {
-      this.commit('addOrUpdateOperation', retrievedOperation.res);
+      this.mutations.addOrUpdateOperation(retrievedOperation.res);
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', retrievedOperation.error);
+      this.errorState.actions.setError(retrievedOperation.error);
       if(retrievedOperation.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', retrievedOperation.errorMsg);
+        this.errorState.actions.setErrorMessage(retrievedOperation.errorMsg);
       }
     } else {
       console.error('Missing Error State');
@@ -114,11 +114,11 @@ class OperationsStateActions extends Actions<OperationsState, OperationsStateGet
   async retrieveOperations({amount, offset, orderBy, orderDir}:{amount?:number, offset?:number, orderBy?:string, orderDir?:string}) {
     const retrievedOperations: ErrorResult<Operation[]> = await retrieveOperations(amount, offset, orderBy, orderDir);
     if(retrievedOperations.res && !retrievedOperations.error) {
-      this.commit('setOperations', retrievedOperations.res);
+      this.mutations.setOperations(retrievedOperations.res);
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', retrievedOperations.error);
+      this.errorState.actions.setError(retrievedOperations.error);
       if(retrievedOperations.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', retrievedOperations.errorMsg);
+        this.errorState.actions.setErrorMessage(retrievedOperations.errorMsg);
       }
     } else {
       console.error('Missing Error State');

--- a/packages/renderer/src/store/Modules/PermissionsState.ts
+++ b/packages/renderer/src/store/Modules/PermissionsState.ts
@@ -64,11 +64,11 @@ class PermissionsStateActions extends Actions<PermissionsState, PermissionsState
   async retrievePermissions(userId: string) {
     const permissions: ErrorResult<Permissions> = await retrievePermissions(userId);
     if(permissions.res && !permissions.error) {
-      this.commit('setPermissions', {userId, permissions: permissions.res});
+      this.mutations.setPermissions({userId, permissions: permissions.res});
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', permissions.error);
+      this.errorState.actions.setError(permissions.error);
       if(permissions.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', permissions.errorMsg);
+        this.errorState.actions.setErrorMessage(permissions.errorMsg);
       }
     } else {
       console.error('Missing Error State');
@@ -78,11 +78,11 @@ class PermissionsStateActions extends Actions<PermissionsState, PermissionsState
     const existingPermissions = this.state.permissions.get(userId);
     const permissionsSet: ErrorResult<boolean> = await updatePermissions(userId, (existingPermissions)? undom(existingPermissions.concat(permissions)):permissions);
     if(permissionsSet.res && !permissionsSet.error) {
-      this.dispatch('retrievePermissions', userId);
+      this.actions.retrievePermissions(userId);
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', permissionsSet.error);
+      this.errorState.actions.setError(permissionsSet.error);
       if(permissionsSet.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', permissionsSet.errorMsg);
+        this.errorState.actions.setErrorMessage(permissionsSet.errorMsg);
       }
     } else {
       console.error('Missing Error State');
@@ -91,11 +91,11 @@ class PermissionsStateActions extends Actions<PermissionsState, PermissionsState
   async updateAllPermissions({userId, permissions}:{userId: string, permissions: Permissions}) {
     const permissionsSet: ErrorResult<boolean> = await updatePermissions(userId, permissions);
     if(permissionsSet.res && !permissionsSet.error) {
-      this.dispatch('retrievePermissions', userId);
+      this.actions.retrievePermissions(userId);
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', permissionsSet.error);
+      this.errorState.actions.setError(permissionsSet.error);
       if(permissionsSet.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', permissionsSet.errorMsg);
+        this.errorState.actions.setErrorMessage(permissionsSet.errorMsg);
       }
     } else {
       console.error('Missing Error State');

--- a/packages/renderer/src/store/Modules/UserState.ts
+++ b/packages/renderer/src/store/Modules/UserState.ts
@@ -72,11 +72,11 @@ class UserStateActions extends Actions<UserState, UserStateGetters, UserStateMut
   async createUser(user: User) {
     const createdUser:ErrorResult<User> = await createUser(undom(user));
     if(createdUser.res && !createdUser.error) {
-      this.commit('addUser', createdUser.res);
+      this.mutations.addUser(createdUser.res);
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', createdUser.error);
+      this.errorState.actions.setError(createdUser.error);
       if(createdUser.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', createdUser.errorMsg);
+        this.errorState.actions.setErrorMessage(createdUser.errorMsg);
       }
     } else {
       console.error('Missing Error State');
@@ -85,11 +85,11 @@ class UserStateActions extends Actions<UserState, UserStateGetters, UserStateMut
   async updateUser(user: User) {
     const userUpdated:ErrorResult<boolean> = await updateUser(undom(user));
     if(userUpdated.res && !userUpdated.error) {
-      this.dispatch('retreiveUserById', user.id);
+      this.actions.retreiveUserById(user.id);
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', userUpdated.error);
+      this.errorState.actions.setError(userUpdated.error);
       if(userUpdated.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', userUpdated.errorMsg);
+        this.errorState.actions.setErrorMessage(userUpdated.errorMsg);
       }
     } else {
       console.error('Missing Error State');
@@ -98,11 +98,11 @@ class UserStateActions extends Actions<UserState, UserStateGetters, UserStateMut
   async deleteUserById(userId: string) {
     const userDeleted: ErrorResult<boolean> = await deleteUser(userId);
     if(userDeleted.res && !userDeleted.error) {
-      this.commit('deleteUserById', userId);
+      this.mutations.deleteUserById(userId);
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', userDeleted.error);
+      this.errorState.actions.setError(userDeleted.error);
       if(userDeleted.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', userDeleted.errorMsg);
+        this.errorState.actions.setErrorMessage(userDeleted.errorMsg);
       }
     } else {
       console.error('Missing Error State');
@@ -111,11 +111,11 @@ class UserStateActions extends Actions<UserState, UserStateGetters, UserStateMut
   async retreiveUsers({amount, offset, orderBy, orderDir}:{amount?:number, offset?:number, orderBy?:string, orderDir?:string}) {
     const retrievedUsers: ErrorResult<User[]> = await retrieveUsers(amount, offset, orderBy, orderDir);
     if(retrievedUsers.res && !retrievedUsers.error) {
-      this.commit('setUsers', retrievedUsers.res);
+      this.mutations.setUsers(retrievedUsers.res);
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', retrievedUsers.error);
+      this.errorState.actions.setError(retrievedUsers.error);
       if(retrievedUsers.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', retrievedUsers.errorMsg);
+        this.errorState.actions.setErrorMessage(retrievedUsers.errorMsg);
       }
     } else {
       console.error('Missing Error State');
@@ -124,11 +124,11 @@ class UserStateActions extends Actions<UserState, UserStateGetters, UserStateMut
   async retreiveUserById(userId: string) {
     const retrievedUser: ErrorResult<User> = await retrieveUser(userId);
     if(retrievedUser.res && !retrievedUser.error) {
-      this.commit('addOrUpdateUser', retrievedUser.res);
+      this.mutations.addOrUpdateUser(retrievedUser.res);
     } else if(this.errorState) {
-      this.errorState.dispatch('setError', retrievedUser.error);
+      this.errorState.actions.setError(retrievedUser.error);
       if(retrievedUser.errorMsg) {
-        this.errorState.dispatch('setErrorMessage', retrievedUser.errorMsg);
+        this.errorState.actions.setErrorMessage(retrievedUser.errorMsg);
       }
     } else {
       console.error('Missing Error State');


### PR DESCRIPTION
Change the action and mutation calls in the vuex state modules to
use the method call style instead of the event emitter style. This
provides more readable and easily understandable type errors and enables
the use of e.g. go to definition in an IDE