### PR TITLE
refactor(vuex-states): move error handling code

### DIFF
--- a/packages/renderer/src/store/Modules/ErrorState.ts
+++ b/packages/renderer/src/store/Modules/ErrorState.ts
@@ -1,4 +1,17 @@
 import { Getters, Mutations, Actions, Module, createComposable } from 'vuex-smart-module';
+import type { Context } from 'vuex-smart-module';
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function handleErrors(error: boolean, errorMsg?: string, errorState?:Context<Module<ErrorState, ErrorStateGetters, ErrorStateMutations, ErrorStateActions, {}>>) {
+  if(errorState) {
+    errorState.actions.setError(error);
+    if(errorMsg) {
+      errorState.actions.setErrorMessage(errorMsg);
+    }
+  } else {
+    console.error('Missing Error State');
+  }
+}
 
 /**
  * define the content of the ErrorState

--- a/packages/renderer/src/store/Modules/GroupState.ts
+++ b/packages/renderer/src/store/Modules/GroupState.ts
@@ -3,7 +3,7 @@ import { createGroup, updateGroup, deleteGroup, retrieveGroup, retrieveGroups } 
 import type { Group, ErrorResult } from '../../../../types';
 import type { Context } from 'vuex-smart-module';
 import type { Store } from 'vuex';
-import { errorState } from './ErrorState';
+import { errorState, handleErrors } from './ErrorState';
 
 function undom(group: Group):Group {
   return {
@@ -65,65 +65,40 @@ class GroupStateActions extends Actions<GroupState, GroupStateGetters, GroupStat
     const createdGroup:ErrorResult<Group> = await createGroup(undom(group));
     if(createdGroup.res && !createdGroup.error) {
       this.mutations.addGroup(createdGroup.res);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(createdGroup.error);
-      if(createdGroup.errorMsg) {
-        this.errorState.actions.setErrorMessage(createdGroup.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(createdGroup.error, createdGroup.errorMsg, this.errorState);
     }
   }
   async updateGroup(group: Group) {
     const groupUpdated:ErrorResult<boolean> = await updateGroup(undom(group));
     if(groupUpdated.res && !groupUpdated.error) {
       this.actions.retrieveGroupById(group.id);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(groupUpdated.error);
-      if(groupUpdated.errorMsg) {
-        this.errorState.actions.setErrorMessage(groupUpdated.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(groupUpdated.error, groupUpdated.errorMsg, this.errorState);
     }
   }
   async deleteGroupById(groupId: string) {
     const groupDeleted:ErrorResult<boolean> = await deleteGroup(groupId);
     if(groupDeleted.res && !groupDeleted.error) {
       this.mutations.deleteGroupById(groupId);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(groupDeleted.error);
-      if(groupDeleted.errorMsg) {
-        this.errorState.actions.setErrorMessage(groupDeleted.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(groupDeleted.error, groupDeleted.errorMsg, this.errorState);
     }
   }
   async retrieveGroups({amount, offset, orderBy, orderDir}:{amount?:number, offset?:number, orderBy?:string, orderDir?:string}) {
     const retrievedGroups:ErrorResult<Group[]> = await retrieveGroups(amount, offset, orderBy, orderDir);
     if(retrievedGroups.res && !retrievedGroups.error) {
       this.mutations.setGroups(retrievedGroups.res);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(retrievedGroups.error);
-      if(retrievedGroups.errorMsg) {
-        this.errorState.actions.setErrorMessage(retrievedGroups.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(retrievedGroups.error, retrievedGroups.errorMsg, this.errorState);
     }
   }
   async retrieveGroupById(groupId: string) {
     const retrievedGroup:ErrorResult<Group> = await retrieveGroup(groupId);
     if(retrievedGroup.res && !retrievedGroup.error) {
       this.mutations.addOrUpdateGroup(retrievedGroup.res);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(retrievedGroup.error);
-      if(retrievedGroup.errorMsg) {
-        this.errorState.actions.setErrorMessage(retrievedGroup.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(retrievedGroup.error, retrievedGroup.errorMsg, this.errorState);
     }
   }
 }

--- a/packages/renderer/src/store/Modules/LoginState.ts
+++ b/packages/renderer/src/store/Modules/LoginState.ts
@@ -3,7 +3,7 @@ import { login, logout } from '#preload';
 import type { ErrorResult } from '../../../../types';
 import type { Context } from 'vuex-smart-module';
 import type { Store } from 'vuex';
-import { errorState } from './ErrorState';
+import { errorState, handleErrors } from './ErrorState';
 
 /**
  * define the content of the LoginInfoState
@@ -65,13 +65,8 @@ class LoginStateActions extends Actions<LoginState, LoginStateGetters, LoginStat
     if(loggedIn.res && !loggedIn.error) {
       this.mutations.setLoggedIn(loggedIn.res);
       this.mutations.setLoggedInUser(username);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(loggedIn.error);
-      if(loggedIn.errorMsg) {
-        this.errorState.actions.setErrorMessage(loggedIn.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(loggedIn.error, loggedIn.errorMsg, this.errorState);
     }
   }
   async setLoggingIn(loggingIn: boolean) {
@@ -81,13 +76,8 @@ class LoginStateActions extends Actions<LoginState, LoginStateGetters, LoginStat
     const loggedOut:ErrorResult<boolean> = await logout();
     if(loggedOut.res && !loggedOut.error) {
       this.mutations.setLoggedIn(false);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(loggedOut.error);
-      if(loggedOut.errorMsg) {
-        this.errorState.actions.setErrorMessage(loggedOut.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(loggedOut.error, loggedOut.errorMsg, this.errorState);
     }
   }
 }

--- a/packages/renderer/src/store/Modules/OperationsState.ts
+++ b/packages/renderer/src/store/Modules/OperationsState.ts
@@ -3,7 +3,7 @@ import {createOperation, updateOperation, retrieveOperation, retrieveOperations 
 import type { Operation, ErrorResult } from '../../../../types';
 import type { Context } from 'vuex-smart-module';
 import type { Store } from 'vuex';
-import { errorState } from './ErrorState';
+import { errorState, handleErrors } from './ErrorState';
 
 function undom(operation: Operation):Operation {
     return {
@@ -73,13 +73,8 @@ class OperationsStateActions extends Actions<OperationsState, OperationsStateGet
     const createdOperation: ErrorResult<Operation> = await createOperation(undom(operation));
     if(createdOperation.res && !createdOperation.error) {
       this.mutations.addOperation(createdOperation.res);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(createdOperation.error);
-      if(createdOperation.errorMsg) {
-        this.errorState.actions.setErrorMessage(createdOperation.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(createdOperation.error, createdOperation.errorMsg, this.errorState);
     }
   }
 
@@ -87,13 +82,8 @@ class OperationsStateActions extends Actions<OperationsState, OperationsStateGet
     const operationUpdated: ErrorResult<boolean> = await updateOperation(undom(operation));
     if(operationUpdated.res && !operationUpdated.error) {
         this.actions.retrieveOperation(operation.id);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(operationUpdated.error);
-      if(operationUpdated.errorMsg) {
-        this.errorState.actions.setErrorMessage(operationUpdated.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(operationUpdated.error, operationUpdated.errorMsg, this.errorState);
     }
   }
 
@@ -101,13 +91,8 @@ class OperationsStateActions extends Actions<OperationsState, OperationsStateGet
     const retrievedOperation: ErrorResult<Operation> = await retrieveOperation(operationId);
     if(retrievedOperation.res && !retrievedOperation.error) {
       this.mutations.addOrUpdateOperation(retrievedOperation.res);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(retrievedOperation.error);
-      if(retrievedOperation.errorMsg) {
-        this.errorState.actions.setErrorMessage(retrievedOperation.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(retrievedOperation.error, retrievedOperation.errorMsg, this.errorState);
     }
   }
 
@@ -115,13 +100,8 @@ class OperationsStateActions extends Actions<OperationsState, OperationsStateGet
     const retrievedOperations: ErrorResult<Operation[]> = await retrieveOperations(amount, offset, orderBy, orderDir);
     if(retrievedOperations.res && !retrievedOperations.error) {
       this.mutations.setOperations(retrievedOperations.res);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(retrievedOperations.error);
-      if(retrievedOperations.errorMsg) {
-        this.errorState.actions.setErrorMessage(retrievedOperations.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(retrievedOperations.error, retrievedOperations.errorMsg, this.errorState);
     }
   }
 }

--- a/packages/renderer/src/store/Modules/PermissionsState.ts
+++ b/packages/renderer/src/store/Modules/PermissionsState.ts
@@ -3,7 +3,7 @@ import { Getters, Mutations, Actions, Module, createComposable } from 'vuex-smar
 import type {Context} from 'vuex-smart-module';
 import { retrievePermissions, updatePermissions } from '#preload';
 import type { Permissions, Permission, ErrorResult } from '../../../../types';
-import { errorState } from './ErrorState';
+import { errorState, handleErrors } from './ErrorState';
 
 
 function undom(permissions: Permissions):Permissions {
@@ -65,13 +65,8 @@ class PermissionsStateActions extends Actions<PermissionsState, PermissionsState
     const permissions: ErrorResult<Permissions> = await retrievePermissions(userId);
     if(permissions.res && !permissions.error) {
       this.mutations.setPermissions({userId, permissions: permissions.res});
-    } else if(this.errorState) {
-      this.errorState.actions.setError(permissions.error);
-      if(permissions.errorMsg) {
-        this.errorState.actions.setErrorMessage(permissions.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(permissions.error, permissions.errorMsg, this.errorState);
     }
   }
   async addPermissions({userId, permissions}:{userId: string, permissions: Permissions}) {
@@ -79,26 +74,16 @@ class PermissionsStateActions extends Actions<PermissionsState, PermissionsState
     const permissionsSet: ErrorResult<boolean> = await updatePermissions(userId, (existingPermissions)? undom(existingPermissions.concat(permissions)):permissions);
     if(permissionsSet.res && !permissionsSet.error) {
       this.actions.retrievePermissions(userId);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(permissionsSet.error);
-      if(permissionsSet.errorMsg) {
-        this.errorState.actions.setErrorMessage(permissionsSet.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(permissionsSet.error, permissionsSet.errorMsg, this.errorState);
     }
   }
   async updateAllPermissions({userId, permissions}:{userId: string, permissions: Permissions}) {
     const permissionsSet: ErrorResult<boolean> = await updatePermissions(userId, permissions);
     if(permissionsSet.res && !permissionsSet.error) {
       this.actions.retrievePermissions(userId);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(permissionsSet.error);
-      if(permissionsSet.errorMsg) {
-        this.errorState.actions.setErrorMessage(permissionsSet.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(permissionsSet.error, permissionsSet.errorMsg, this.errorState);
     }
   }
 }

--- a/packages/renderer/src/store/Modules/UserState.ts
+++ b/packages/renderer/src/store/Modules/UserState.ts
@@ -3,7 +3,7 @@ import { Getters, Mutations, Actions, Module, createComposable } from 'vuex-smar
 import type { Context } from 'vuex-smart-module';
 import { createUser, updateUser, deleteUser, retrieveUser, retrieveUsers } from '#preload';
 import type { User, ErrorResult } from '../../../../types';
-import { errorState } from './ErrorState';
+import { errorState, handleErrors } from './ErrorState';
 
 function undom(user: User):User {
   return {...user};
@@ -73,65 +73,40 @@ class UserStateActions extends Actions<UserState, UserStateGetters, UserStateMut
     const createdUser:ErrorResult<User> = await createUser(undom(user));
     if(createdUser.res && !createdUser.error) {
       this.mutations.addUser(createdUser.res);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(createdUser.error);
-      if(createdUser.errorMsg) {
-        this.errorState.actions.setErrorMessage(createdUser.errorMsg);
-      }
     } else {
-      console.error('Missing Error State');
+      handleErrors(createdUser.error, createdUser.errorMsg, this.errorState);
     }
   }
   async updateUser(user: User) {
     const userUpdated:ErrorResult<boolean> = await updateUser(undom(user));
     if(userUpdated.res && !userUpdated.error) {
       this.actions.retreiveUserById(user.id);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(userUpdated.error);
-      if(userUpdated.errorMsg) {
-        this.errorState.actions.setErrorMessage(userUpdated.errorMsg);
-      }
     } else {
-      console.error('Missing Error State');
+      handleErrors(userUpdated.error, userUpdated.errorMsg, this.errorState);
     }
   }
   async deleteUserById(userId: string) {
     const userDeleted: ErrorResult<boolean> = await deleteUser(userId);
     if(userDeleted.res && !userDeleted.error) {
       this.mutations.deleteUserById(userId);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(userDeleted.error);
-      if(userDeleted.errorMsg) {
-        this.errorState.actions.setErrorMessage(userDeleted.errorMsg);
-      }
-    } else {
-      console.error('Missing Error State');
+    }  else {
+      handleErrors(userDeleted.error, userDeleted.errorMsg, this.errorState);
     }
   }
   async retreiveUsers({amount, offset, orderBy, orderDir}:{amount?:number, offset?:number, orderBy?:string, orderDir?:string}) {
     const retrievedUsers: ErrorResult<User[]> = await retrieveUsers(amount, offset, orderBy, orderDir);
     if(retrievedUsers.res && !retrievedUsers.error) {
       this.mutations.setUsers(retrievedUsers.res);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(retrievedUsers.error);
-      if(retrievedUsers.errorMsg) {
-        this.errorState.actions.setErrorMessage(retrievedUsers.errorMsg);
-      }
     } else {
-      console.error('Missing Error State');
+      handleErrors(retrievedUsers.error, retrievedUsers.errorMsg, this.errorState);
     }
   }
   async retreiveUserById(userId: string) {
     const retrievedUser: ErrorResult<User> = await retrieveUser(userId);
     if(retrievedUser.res && !retrievedUser.error) {
       this.mutations.addOrUpdateUser(retrievedUser.res);
-    } else if(this.errorState) {
-      this.errorState.actions.setError(retrievedUser.error);
-      if(retrievedUser.errorMsg) {
-        this.errorState.actions.setErrorMessage(retrievedUser.errorMsg);
-      }
     } else {
-      console.error('Missing Error State');
+      handleErrors(retrievedUser.error, retrievedUser.errorMsg, this.errorState);
     }
   }
 }


### PR DESCRIPTION
The error handling code was repeated many times at the exact same
location in every action in every state. To make this code more
maintainable and easier to change it was moved into its own function
in the ErrorState