### PR TITLE
refactor: use attr inheritance with NormalButton

### DIFF
--- a/packages/renderer/src/components/BasicComponents/NormalButton.vue
+++ b/packages/renderer/src/components/BasicComponents/NormalButton.vue
@@ -1,13 +1,19 @@
 <template>
   <button
-    :id="props.btnId"
-    :type="props.btnType"
     class="text-on_primary bg-primary hover:bg-primary_dark hover:text-on_primary_dark focus:ring-4 focus:outline-none focus:ring-primary_light font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center"
-    @click.prevent="$emit('btn-click', $event)"
+    v-bind="$attrs"
+    @click="$emit('click', $event)"
   >
     {{ props.btnText }}
   </button>
 </template>
+
+<script lang="ts">
+  export default {
+    inheritAttrs: false,
+  };
+</script>
+
 <script lang="ts" setup>
   /**
    * Normal button component represents a 
@@ -20,12 +26,10 @@
    */
   interface Props {
     btnText: string;
-    btnId?: string;
-    btnType?: 'submit' | 'reset' | 'button' | undefined;
   }
   const props = defineProps<Props>();
   // eslint-disable-next-line
   const emits = defineEmits<{
-    (name: 'btn-click', e: MouseEvent ): void
+    (name: 'click', e: MouseEvent ): void
   }>();
 </script>

--- a/packages/renderer/src/components/LoginForm.vue
+++ b/packages/renderer/src/components/LoginForm.vue
@@ -16,10 +16,10 @@
         type="password"
       />
       <NormalButton
+        id="submit"
         btn-text="Login"
-        btn-id="submit"
-        btn-type="submit"
-        @btn-click="onSubmit"
+        type="submit"
+        @click.prevent="onSubmit"
       />
     </form>
   </main>

--- a/packages/renderer/src/views/CreateNewUser.vue
+++ b/packages/renderer/src/views/CreateNewUser.vue
@@ -36,8 +36,8 @@
         <NormalButton
           id="submit"
           btn-text="Submit"
-          btn-type="submit"
-          @btn-click="onSubmit"
+          type="submit"
+          @click.prevent="onSubmit"
         />
       </main>
     </form>

--- a/packages/renderer/src/views/MainApplication.vue
+++ b/packages/renderer/src/views/MainApplication.vue
@@ -15,28 +15,28 @@
     <div>{{ user }}:{{ permissions().get(user.id) }}</div>
     <NormalButton
       :btn-text="`Update ${user.username}`"
-      @btn-click="updateUser(user.id)"
+      @click.prevent="updateUser(user.id)"
     />
     <NormalButton
       :btn-text="`Update Password for ${user.username}`"
-      @btn-click="updateUserPw(user.id)"
+      @click.prevent="updateUserPw(user.id)"
     />
     <NormalButton
       :btn-text="`Delete ${user.username}`"
-      @btn-click="deleteUser(user.id)"
+      @click.prevent="deleteUser(user.id)"
     />
     <NormalButton
       :btn-text="`Add user.create Permission to ${user.username}`"
-      @btn-click="addCreatePermission(user.id)"
+      @click.prevent="addCreatePermission(user.id)"
     />
     <NormalButton
       :btn-text="`Add user.delete Permission to ${user.username}`"
-      @btn-click="addDeletePermission(user.id)"
+      @click.prevent="addDeletePermission(user.id)"
     />
   </div>
   <NormalButton
     btn-text="Generate New User"
-    @btn-click="generateUser()"
+    @click.prevent="generateUser()"
   />
   <form>
     <FormInput
@@ -45,15 +45,15 @@
       label="Username"
     />
     <NormalButton
+      id="submit"
       btn-text="Fetch User By Id"
-      btn-id="submit"
-      btn-type="submit"
-      @btn-click="fetchUser(userId)"
+      type="submit"
+      @click.prevent="fetchUser(userId)"
     />
   </form>
   <NormalButton
     btn-text="Load Permissions"
-    @btn-click="loadPermissions()"
+    @click.prevent="loadPermissions()"
   />
   <div
     v-for="operation in operations()"
@@ -62,12 +62,12 @@
     <div>{{ operation }}</div>
     <NormalButton
       :btn-text="`Update ${operation.title}`"
-      @btn-click="updateOperation(operation.id)"
+      @click.prevent="updateOperation(operation.id)"
     />
   </div>
   <NormalButton
     btn-text="Generate New Operation"
-    @btn-click="generateOperation()"
+    @click.prevent="generateOperation()"
   />
   <form>
     <FormInput
@@ -76,10 +76,10 @@
       label="Operation"
     />
     <NormalButton
+      id="submit"
       btn-text="Fetch Operation By Id"
-      btn-id="submit"
-      btn-type="submit"
-      @btn-click="fetchOperation(operationId)"
+      type="submit"
+      @click.prevent="fetchOperation(operationId)"
     />
   </form>
   <div
@@ -89,16 +89,16 @@
     <div>{{ group }}</div>
     <NormalButton
       :btn-text="`Update ${group.title}`"
-      @btn-click="updateGroup(group.id)"
+      @click.prevent="updateGroup(group.id)"
     />
     <NormalButton
       :btn-text="`Delete ${group.title}`"
-      @btn-click="deleteGroup(group.id)"
+      @click.prevent="deleteGroup(group.id)"
     />
   </div>
   <NormalButton
     btn-text="Generate New Group"
-    @btn-click="generateGroup()"
+    @click.prevent="generateGroup()"
   />
   <form>
     <FormInput
@@ -107,10 +107,10 @@
       label="Group"
     />
     <NormalButton
+      id="submit"
       btn-text="Fetch Group By Id"
-      btn-id="submit"
-      btn-type="submit"
-      @btn-click="fetchGroup(groupId)"
+      type="submit"
+      @click.prevent="fetchGroup(groupId)"
     />
   </form>
 </template>


### PR DESCRIPTION
Change the NormalButton component to use vue attribute inheritance
instead of specifically defined props to be more consistent with other
components and to be more reliable and robust. Also change all uses
of the NormalButton component to reflect the change.