### PR TITLE
fix(vuex user state): fix user duplication bug

### DIFF
--- a/packages/renderer/src/store/Modules/UserState.ts
+++ b/packages/renderer/src/store/Modules/UserState.ts
@@ -38,9 +38,9 @@ class UserStateMutations extends Mutations<UserState> {
     this.state.users = [...this.state.users, user];
   }
   addOrUpdateUser(user: User){
-    if (this.state.users.filter((elem) => elem.username === user.username).length > 0) {
-      this.state.users = this.state.users.map((elem) => (elem.username === user.username)? user : elem);
-    } else {
+    if (this.state.users.filter((elem) => elem.id === user.id).length > 0) {
+      this.state.users = this.state.users.map((elem) => (elem.id === user.id)? user : elem);
+    } else{
       this.state.users = [...this.state.users, user];
     }
   }

--- a/packages/renderer/src/views/MainApplication.vue
+++ b/packages/renderer/src/views/MainApplication.vue
@@ -156,7 +156,7 @@ import FormInput from '../components/BasicComponents/FormInput.vue';
 
   function updateUser(userId: string) {
     const updatedUser = users.value().filter((elem) => elem.id === userId)[0];
-    userState.dispatch('updateUser', {...updatedUser, first_name: `${updatedUser.first_name}u`});
+    userState.dispatch('updateUser', {...updatedUser, username: `${updatedUser.username}u`});
   }
 
   function deleteUser(userId: string) {


### PR DESCRIPTION
fix a bug where users are erroneously inserted into the users array
instead the existing user being updated if the username is changed.
This is caused by the addOrUpdateUser method checking if the usernames
are the same for determining object equality. The fix is to just use
the id for checking object equality