### PR TITLE
refactor(groups-ui): do not redirect on creation

### DIFF
--- a/packages/renderer/src/views/CreateNewGroup.vue
+++ b/packages/renderer/src/views/CreateNewGroup.vue
@@ -173,7 +173,10 @@
         operation: updatedGroupOperationId.value? updatedGroupOperationId.value: undefined,
         members: checkPermissions([{name: PermissionNames.OperationMembersView}]) ? updatedGroupMemberIds.value : [],
       });
-      router.push('/groups');
+      updatedGroupTitle.value = '';
+      updatedGroupDescription.value = '';
+      updatedGroupOperationId.value = '';
+      updatedGroupMemberIds.value = [];
   }
 
   /**


### PR DESCRIPTION
Now works like users and operations ui where the create button does not redirect to the all users or all operations page. The create group button now creates the group and only clears the v-models.