### PR TITLE
fix: fix pagination order-by fields being ignored

### DIFF
--- a/src/app/core/util/net.ts
+++ b/src/app/core/util/net.ts
@@ -173,7 +173,7 @@ export function netPaginationParams<T>(sParams: PaginationParams<T>, mapOrderBy:
   return {
     limit: sParams.limit,
     offset: sParams.offset,
-    order_by: !!sParams.orderBy ? mapOrderBy(sParams.orderBy) : undefined,
+    order_by: sParams.orderBy !== undefined ? mapOrderBy(sParams.orderBy) : undefined,
     order_dir: netOrderDir,
   };
 }


### PR DESCRIPTION
Fixes an issue where the order-by field mapping function would not have been called and therefore wrong order-by fields sent in net requests with pagination.

Closes #128