### PR TITLE
refactor: add loading dots

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -24,6 +24,7 @@ import { LoadingDotsComponent } from './components/loading-dots/loading-dots.com
 import { SearchableEntityInputComponent } from './components/searchable-entity-input/searchable-entity-input.component';
 import { ErrorsComponent } from './components/errors/errors.component';
 import { LocalPaginatedListComponent } from './components/local-paginated-list/local-paginated-list.component';
+import { ShowLoadingDotsDirective } from './directives/show-loading-dots.directive';
 
 
 @NgModule({
@@ -47,6 +48,7 @@ import { LocalPaginatedListComponent } from './components/local-paginated-list/l
     SearchableEntityInputComponent,
     ErrorsComponent,
     LocalPaginatedListComponent,
+    ShowLoadingDotsDirective,
   ],
   exports: [
     LogoComponent,
@@ -66,6 +68,7 @@ import { LocalPaginatedListComponent } from './components/local-paginated-list/l
     SearchableEntityInputComponent,
     ErrorsComponent,
     LocalPaginatedListComponent,
+    ShowLoadingDotsDirective,
   ],
   imports: [
     CommonModule,

--- a/src/app/core/directives/loading-overlay.ts
+++ b/src/app/core/directives/loading-overlay.ts
@@ -1,0 +1,146 @@
+import {
+  ComponentType,
+  Overlay,
+  OverlayConfig,
+  OverlayContainer,
+  OverlayKeyboardDispatcher,
+  OverlayOutsideClickDispatcher,
+  OverlayPositionBuilder,
+  OverlayRef,
+  ScrollDispatcher,
+  ScrollStrategyOptions,
+  ViewportRuler,
+} from '@angular/cdk/overlay';
+import {
+  ComponentFactoryResolver,
+  Directive,
+  ElementRef,
+  Inject,
+  Injector,
+  NgZone,
+  Renderer2,
+  RendererFactory2,
+} from '@angular/core';
+import { DOCUMENT, Location } from '@angular/common';
+import { Directionality } from '@angular/cdk/bidi';
+import { Platform } from '@angular/cdk/platform';
+import { ComponentPortal } from '@angular/cdk/portal';
+
+export class DynamicOverlay extends Overlay {
+  private readonly _dynamicOverlayContainer: DynamicOverlayContainer;
+  private renderer: Renderer2;
+
+  constructor(
+    scrollStrategies: ScrollStrategyOptions,
+    _overlayContainer: DynamicOverlayContainer,
+    _componentFactoryResolver: ComponentFactoryResolver,
+    _positionBuilder: OverlayPositionBuilder,
+    _keyboardDispatcher: OverlayKeyboardDispatcher,
+    _injector: Injector,
+    _ngZone: NgZone,
+    @Inject(DOCUMENT) _document: any,
+    _directionality: Directionality,
+    rendererFactory: RendererFactory2,
+    location: Location,
+    clickOutsideDispatcher: OverlayOutsideClickDispatcher,
+  ) {
+    super(
+      scrollStrategies,
+      _overlayContainer,
+      _componentFactoryResolver,
+      _positionBuilder,
+      _keyboardDispatcher,
+      _injector,
+      _ngZone,
+      _document,
+      _directionality,
+      location,
+      clickOutsideDispatcher,
+    );
+    this.renderer = rendererFactory.createRenderer(null, null);
+
+    this._dynamicOverlayContainer = _overlayContainer;
+  }
+
+  public setContainerElement(containerElement: HTMLElement): void {
+    this.renderer.setStyle(containerElement, 'transform', 'translateZ(0)');
+    this._dynamicOverlayContainer.setContainerElement(containerElement);
+  }
+
+  private getDefaultConfig(): OverlayConfig {
+    return {
+      positionStrategy: this.position()
+        .global()
+        .centerHorizontally()
+        .centerVertically(),
+    };
+  }
+
+  public createWithBackdrop(backdropClass: string | string[] | undefined): OverlayRef {
+    return super.create({
+      ...this.getDefaultConfig(),
+      backdropClass: backdropClass,
+      hasBackdrop: true,
+    });
+  }
+}
+
+export class DynamicOverlayContainer extends OverlayContainer {
+  public setContainerElement(containerElement: HTMLElement): void {
+    this._containerElement = containerElement;
+  }
+}
+
+@Directive()
+export class LoadingOverlay {
+
+  private overlayRef?: OverlayRef;
+  private readonly scrollStrategyOptions: ScrollStrategyOptions;
+  private overlay?: DynamicOverlay;
+
+  constructor(
+    private _componentFactoryResolver: ComponentFactoryResolver,
+    private _positionBuilder: OverlayPositionBuilder,
+    private _keyboardDispatcher: OverlayKeyboardDispatcher,
+    private _injector: Injector,
+    private _ngZone: NgZone,
+    @Inject(DOCUMENT) private _document: any,
+    private _directionality: Directionality,
+    private rendererFactory: RendererFactory2,
+    private location: Location,
+    private clickOutsideDispatcher: OverlayOutsideClickDispatcher,
+    private _platform: Platform,
+    private elementRef: ElementRef,
+    _scrollDispatcher: ScrollDispatcher,
+    _viewPortRuler: ViewportRuler,
+  ) {
+    this.scrollStrategyOptions = new ScrollStrategyOptions(_scrollDispatcher, _viewPortRuler, _ngZone, _document);
+  }
+
+  protected attach(genOverlay: (overlay: DynamicOverlay) => OverlayRef, componentType: ComponentType<any>): void {
+    this.overlayRef?.detach();
+    const overlayContainer = new DynamicOverlayContainer(this._document, this._platform);
+    overlayContainer.setContainerElement(this.elementRef.nativeElement);
+    this.overlay = new DynamicOverlay(
+      this.scrollStrategyOptions,
+      overlayContainer,
+      this._componentFactoryResolver,
+      this._positionBuilder,
+      this._keyboardDispatcher,
+      this._injector,
+      this._ngZone,
+      this._document,
+      this._directionality,
+      this.rendererFactory,
+      this.location,
+      this.clickOutsideDispatcher,
+    );
+    this.overlay.setContainerElement(this.elementRef.nativeElement);
+    this.overlayRef = genOverlay(this.overlay);
+    this.overlayRef.attach(new ComponentPortal(componentType));
+  }
+
+  protected detach(): void {
+    this.overlayRef?.detach();
+  }
+}

--- a/src/app/core/directives/show-loading-dots.directive.ts
+++ b/src/app/core/directives/show-loading-dots.directive.ts
@@ -1,0 +1,41 @@
+import { Directive, Input, OnDestroy } from '@angular/core';
+import { Subscription, timer } from 'rxjs';
+import { LoadingOverlay } from './loading-overlay';
+import { LoadingDotsComponent } from '../components/loading-dots/loading-dots.component';
+
+/**
+ * Delay for showing the dots.
+ */
+const AttachDelayMS = 200;
+
+@Directive({
+  selector: '[appShowLoadingDots]',
+})
+export class ShowLoadingDotsDirective extends LoadingOverlay implements OnDestroy {
+  private s?: Subscription;
+
+  @Input()
+  set appShowLoadingDots(value: boolean | null) {
+    if (value) {
+      this.attachLoader();
+    } else {
+      this.detachLoader();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.detachLoader();
+  }
+
+  private attachLoader() {
+    this.s?.unsubscribe();
+    this.s = timer(AttachDelayMS).subscribe(() => {
+      super.attach(overlay => overlay.createWithBackdrop('_loading-dots-backdrop'), LoadingDotsComponent);
+    });
+  }
+
+  private detachLoader() {
+    this.s?.unsubscribe();
+    super.detach();
+  }
+}

--- a/src/app/core/directives/show-loading-overlay.directive.ts
+++ b/src/app/core/directives/show-loading-overlay.directive.ts
@@ -1,97 +1,12 @@
-import {
-  ComponentFactoryResolver,
-  Directive,
-  ElementRef,
-  Inject,
-  Injector,
-  Input,
-  NgZone,
-  OnDestroy,
-  Renderer2,
-  RendererFactory2,
-} from '@angular/core';
-import { ComponentPortal } from '@angular/cdk/portal';
+import { Directive, Input, OnDestroy } from '@angular/core';
 import { Subscription, timer } from 'rxjs';
-import {
-  Overlay,
-  OverlayContainer,
-  OverlayKeyboardDispatcher,
-  OverlayOutsideClickDispatcher,
-  OverlayPositionBuilder,
-  OverlayRef,
-  ScrollDispatcher,
-  ScrollStrategyOptions,
-  ViewportRuler,
-} from '@angular/cdk/overlay';
 import { LoadingOverlayComponent } from '../components/loading-overlay/loading-overlay.component';
-import { Directionality } from '@angular/cdk/bidi';
-import { DOCUMENT, Location } from '@angular/common';
-import { Platform } from '@angular/cdk/platform';
+import { LoadingOverlay } from './loading-overlay';
 
 /**
  * Delay for showing the overlay.
  */
 const AttachDelayMS = 500;
-
-export class DynamicOverlay extends Overlay {
-  private readonly _dynamicOverlayContainer: DynamicOverlayContainer;
-  private renderer: Renderer2;
-
-  constructor(
-    scrollStrategies: ScrollStrategyOptions,
-    _overlayContainer: DynamicOverlayContainer,
-    _componentFactoryResolver: ComponentFactoryResolver,
-    _positionBuilder: OverlayPositionBuilder,
-    _keyboardDispatcher: OverlayKeyboardDispatcher,
-    _injector: Injector,
-    _ngZone: NgZone,
-    @Inject(DOCUMENT) _document: any,
-    _directionality: Directionality,
-    rendererFactory: RendererFactory2,
-    location: Location,
-    clickOutsideDispatcher: OverlayOutsideClickDispatcher,
-  ) {
-    super(
-      scrollStrategies,
-      _overlayContainer,
-      _componentFactoryResolver,
-      _positionBuilder,
-      _keyboardDispatcher,
-      _injector,
-      _ngZone,
-      _document,
-      _directionality,
-      location,
-      clickOutsideDispatcher,
-    );
-    this.renderer = rendererFactory.createRenderer(null, null);
-
-    this._dynamicOverlayContainer = _overlayContainer;
-  }
-
-  public setContainerElement(containerElement: HTMLElement): void {
-    this.renderer.setStyle(containerElement, 'transform', 'translateZ(0)');
-    this._dynamicOverlayContainer.setContainerElement(containerElement);
-  }
-
-  public createWithDefaultConfig(containerElement: HTMLElement): OverlayRef {
-    this.setContainerElement(containerElement);
-    return super.create({
-      backdropClass: '_loading-overlay-backdrop',
-      positionStrategy: this.position()
-        .global()
-        .centerHorizontally()
-        .centerVertically(),
-      hasBackdrop: true,
-    });
-  }
-}
-
-class DynamicOverlayContainer extends OverlayContainer {
-  public setContainerElement(containerElement: HTMLElement): void {
-    this._containerElement = containerElement;
-  }
-}
 
 /**
  * Directive for showing a loader overlay for components.
@@ -101,16 +16,11 @@ class DynamicOverlayContainer extends OverlayContainer {
 @Directive({
   selector: '[appShowLoadingOverlay]',
 })
-export class ShowLoadingOverlayDirective implements OnDestroy {
-
-  overlayRef?: OverlayRef;
-  currentSubscription: Subscription | undefined;
-  private scrollStrategyOptions: ScrollStrategyOptions;
-  private overlay?: DynamicOverlay;
+export class ShowLoadingOverlayDirective extends LoadingOverlay implements OnDestroy {
+  private s?: Subscription;
 
   @Input()
   set appShowLoadingOverlay(value: boolean | null) {
-    this.unsubscribeCurrentSubscription();
     if (value) {
       this.attachLoader();
     } else {
@@ -118,65 +28,19 @@ export class ShowLoadingOverlayDirective implements OnDestroy {
     }
   }
 
-  constructor(
-    private _componentFactoryResolver: ComponentFactoryResolver,
-    private _positionBuilder: OverlayPositionBuilder,
-    private _keyboardDispatcher: OverlayKeyboardDispatcher,
-    private _injector: Injector,
-    private _ngZone: NgZone,
-    @Inject(DOCUMENT) private _document: any,
-    private _directionality: Directionality,
-    private rendererFactory: RendererFactory2,
-    private location: Location,
-    private clickOutsideDispatcher: OverlayOutsideClickDispatcher,
-    private _platform: Platform,
-    private elementRef: ElementRef,
-    _scrollDispatcher: ScrollDispatcher,
-    _viewPortRuler: ViewportRuler,
-  ) {
-    this.scrollStrategyOptions = new ScrollStrategyOptions(_scrollDispatcher, _viewPortRuler, _ngZone, _document);
-  }
-
   ngOnDestroy(): void {
     this.detachLoader();
-    this.unsubscribeCurrentSubscription();
   }
-
-  private unsubscribeCurrentSubscription() {
-    if (this.currentSubscription) {
-      this.detachLoader();
-      this.currentSubscription.unsubscribe();
-    }
-  }
-
-  private s?: Subscription;
 
   private attachLoader() {
+    this.s?.unsubscribe();
     this.s = timer(AttachDelayMS).subscribe(() => {
-      this.overlayRef?.detach();
-      const overlayContainer = new DynamicOverlayContainer(this._document, this._platform);
-      overlayContainer.setContainerElement(this.elementRef.nativeElement);
-      this.overlay = new DynamicOverlay(
-        this.scrollStrategyOptions,
-        overlayContainer,
-        this._componentFactoryResolver,
-        this._positionBuilder,
-        this._keyboardDispatcher,
-        this._injector,
-        this._ngZone,
-        this._document,
-        this._directionality,
-        this.rendererFactory,
-        this.location,
-        this.clickOutsideDispatcher,
-      );
-      this.overlayRef = this.overlay.createWithDefaultConfig(this.elementRef.nativeElement);
-      this.overlayRef.attach(new ComponentPortal(LoadingOverlayComponent));
+      super.attach(overlay => overlay.createWithBackdrop('_loading-overlay-backdrop'), LoadingOverlayComponent);
     });
   }
 
   private detachLoader() {
     this.s?.unsubscribe();
-    this.overlayRef?.detach()
+    super.detach();
   }
 }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -5,6 +5,10 @@
   backdrop-filter: brightness(0.95);
 }
 
+._loading-dots-backdrop {
+  pointer-events: none;
+}
+
 .clickable {
   cursor: pointer;
 }


### PR DESCRIPTION
Adds loading dots which are similar to loading overlays but for usage in containers where no backdrop is wanted and space is limited. This might include pending data in table rows.