### PR TITLE
[BUG]: Editing entry channels during creation results in unintended behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@angular/cli": "~15.0.3",
         "@angular/compiler-cli": "^15.0.3",
         "@types/jasmine": "~4.0.0",
+        "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.43.0",
         "@typescript-eslint/parser": "^5.43.0",
         "eslint": "^8.28.0",
@@ -4511,6 +4512,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -17235,6 +17242,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+      "dev": true
     },
     "@types/ws": {
       "version": "8.5.3",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@angular/cli": "~15.0.3",
     "@angular/compiler-cli": "^15.0.3",
     "@types/jasmine": "~4.0.0",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",
     "eslint": "^8.28.0",

--- a/src/app/features/logistics/channels/channel-details-dialog/channel-details-dialog.component.ts
+++ b/src/app/features/logistics/channels/channel-details-dialog/channel-details-dialog.component.ts
@@ -4,6 +4,7 @@ import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dial
 import { FormBuilder, Validators } from '@angular/forms';
 import * as moment from 'moment';
 import { ValidatorDurationMin, ValidatorDurationRequired } from '../../../../core/util/duration';
+import * as uuid from 'uuid';
 
 /**
  * Dialog data for {@link ChannelDetailsDialog}.
@@ -71,7 +72,7 @@ export class ChannelDetailsDialog {
   closeSubmit(): void {
     const v = this.form.getRawValue();
     const channel: ChannelBase = {
-      id: v.id ?? undefined,
+      id: v.id ?? uuid.v4(),
       entry: v.entry!,
       isActive: v.isActive,
       label: v.label,


### PR DESCRIPTION
fix: fixed bug "Editing entry channels during creation results in unintended behavior". Missing id was causing the entries to behave like they were the same (all new created ids were undefined). Therefore I assigned them uuids.