### PR TITLE
fixed [BUG]: Toolbar not fixed

### DIFF
--- a/src/app/core/components/home-layout/home-layout.component.scss
+++ b/src/app/core/components/home-layout/home-layout.component.scss
@@ -13,6 +13,13 @@
   max-height: 64px !important;
 }
 
+mat-toolbar{
+  position: sticky;
+  position: -webkit-sticky; /* For macOS/iOS Safari */
+  top: 0; /* Sets the sticky toolbar to be on top */
+  z-index: 1000; /* Ensure that your app's content doesn't overlap the toolbar */
+}
+
 .logo {
   font-size: .2rem;
 }


### PR DESCRIPTION
Set toolbar sticky on top of the screen. Used position: -webkit-sticky to make sure it also works on iOS (this is shown red by the analysys but should not have any negative effects).